### PR TITLE
Tidy up translcomprehension

### DIFF
--- a/lambda/translcomprehension.ml
+++ b/lambda/translcomprehension.ml
@@ -2,304 +2,406 @@ open Lambda
 open Typedtree
 open Asttypes
 
-type comp_block =
-  | Unguarded of lambda * array_kind
-  | Guarded of lambda * array_kind * int
-
-type arrays =
-  | Array_of_elements
-  | Array_of_arrays of arrays
-  | Array_of_filtered_arrays of arrays
-
 let int n = Lconst (Const_base (Const_int n))
 
-let empty_arr ~loc=
-  Lprim( (Pmakearray(Pgenarray, Immutable)), [] ,loc)
+type binding =
+  { let_kind : let_kind;
+    value_kind : value_kind;
+    var : Ident.t;
+    init : lambda }
 
-let make_array size init ~loc=
-  let prim_make_arr =
+let binding let_kind value_kind var init =
+  {let_kind; value_kind; var; init}
+
+let gen_binding {let_kind; value_kind; var; init} body =
+  Llet(let_kind, value_kind, var, init, body)
+
+let gen_bindings bindings body =
+  List.fold_right gen_binding bindings body
+
+(* Translate a clause into some initialising bindings, a variable
+   that will be bound to the number of iterations in the clause by
+   those bindings, and lambda code that performs the iterations. *)
+let transl_arr_clause ~transl_exp ~scopes ~loc clause body =
+  let len_var = Ident.create_local "len_var" in
+  let bindings, for_ =
+    match clause with
+    | In (pat , e2) ->
+        let in_var = Ident.create_local "in_var" in
+        let in_kind = Typeopt.array_kind e2 in
+        let in_binding =
+          binding Strict Pgenval in_var (transl_exp ~scopes e2)
+        in
+        let len_binding =
+          let init = Lprim( (Parraylength(in_kind)), [Lvar(in_var)], loc) in
+          binding Alias Pintval len_var init
+        in
+        let index = Ident.create_local "index" in
+        let for_ =
+          Lfor(index, (int 0), Lprim(Psubint, [Lvar(len_var); int 1], loc) , Upto,
+            Matching.for_let ~scopes pat.pat_loc
+              (Lprim(Parrayrefu(in_kind),
+                     [Lvar(in_var); Lvar(index)], loc)) pat body)
+        in
+        [in_binding; len_binding], for_
+    | From_to(id, _, e2, e3, dir) ->
+        let from_var = Ident.create_local "from" in
+        let from_binding =
+          binding Strict Pintval from_var (transl_exp ~scopes e2)
+        in
+        let to_var = Ident.create_local "to" in
+        let to_binding =
+          binding Strict Pintval to_var (transl_exp ~scopes e3)
+        in
+        let low, high =
+          match dir with
+          | Upto -> Lvar from_var, Lvar to_var
+          | Downto -> Lvar to_var, Lvar from_var
+        in
+        let len_binding =
+          let init =
+            Lprim(Psubint, [Lprim(Paddint, [high; int 1], loc); low], loc)
+          in
+          binding Alias Pintval len_var init
+        in
+        let for_ = Lfor(id, Lvar from_var, Lvar to_var, dir, body) in
+        [from_binding; to_binding; len_binding], for_
+  in
+  bindings, len_var, for_
+
+(* Generate code to iterate over a comprehension block, along with some
+   initialising bindings.  The bindings will also bind the given
+   [length_var] ident to the total number2 of iterations in the
+   block. *)
+let iterate_arr_block ~transl_exp ~loc ~scopes
+      {clauses; guard} length_var body =
+  let body =
+    match guard with
+    | None -> body
+    | Some guard ->
+      Lifthenelse(transl_exp ~scopes guard, body, lambda_unit)
+  in
+  let body, lengths, rev_bindings =
+    List.fold_left
+      (fun (body, lengths, rev_bindings) clause ->
+         let new_bindings, new_length_var, body =
+           transl_arr_clause ~transl_exp ~scopes ~loc clause body
+         in
+         let rev_bindings = List.rev_append new_bindings rev_bindings in
+         let lengths = new_length_var :: lengths in
+         body, lengths, rev_bindings)
+      (body, [], []) clauses
+  in
+  let length_opt =
+    List.fold_left
+      (fun length var ->
+         match length with
+         | None -> Some (Lvar var)
+         | Some length -> Some (Lprim(Pmulint, [Lvar var; length], loc)))
+      None lengths
+  in
+  let length = Option.value length_opt ~default:(int 0) in
+  let length_binding = binding Alias Pintval length_var length in
+  let bindings = List.rev_append rev_bindings [length_binding] in
+  bindings, body
+
+let make_array_prim ~loc size init =
+  let prim =
     Primitive.simple ~name:"caml_make_vect" ~arity:2 ~alloc:true
   in
-  Lprim (Pccall prim_make_arr, [size; init], loc)
+  Lprim (Pccall prim, [size; init], loc)
 
-let make_array_of_kind kind size ~loc =
-  match kind with
-  | Pgenarray -> assert false (*An example is needed to create this array.*)
-  | Pintarray -> make_array size (int 0) ~loc
-  | Paddrarray -> make_array size (int 0) ~loc
-  | Pfloatarray ->
-    let prim_make_float_arr =
-      Primitive.simple ~name:"caml_make_float_vect" ~arity:1 ~alloc:true
-    in
-    Lprim (Pccall prim_make_float_arr, [size], loc)
+let make_floatarray_prim ~loc size =
+  let prim =
+    Primitive.simple ~name:"caml_make_float_vect" ~arity:1 ~alloc:true
+  in
+  Lprim (Pccall prim, [size], loc)
 
-let blit_array src src_pos dst dst_pos len ~loc=
+let blit_array_prim ~loc src src_pos dst dst_pos len =
   let prim_blit_arr =
     Primitive.simple ~name:"caml_array_blit" ~arity:5 ~alloc:true
   in
   Lprim (Pccall prim_blit_arr, [src; src_pos; dst; dst_pos; len], loc)
 
-let transl_loop ~type_comp ~body ~scopes ~loc  ~transl_exp ~mats  =
-  let len_var = Ident.create_local "len_var" in
-  match type_comp with
-  | In (pat , e2) ->
-    let in_ = transl_exp ~scopes e2 in
-    let in_var = Ident.create_local "in_var" in
-    let in_kind = Typeopt.array_kind e2 in
-    let len = Lprim( (Parraylength(in_kind)), [Lvar(in_var)], loc) in
-    let index = Ident.create_local "index" in
-    let mats = (in_var, in_)::mats in
-    Lfor(index, (int 0), Lprim(Psubint, [Lvar(len_var); int 1], loc) , Upto,
-      Matching.for_let ~scopes pat.pat_loc
-        (Lprim(Parrayrefs(in_kind),
-          [Lvar(in_var); Lvar(index)], loc)) pat body), (len_var,len), mats
-    
-  | From_to(id, _, e2, e3, dir) ->
-    let from = transl_exp ~scopes e2 in
-    let to_ = transl_exp ~scopes e3 in
-    let from_var = Ident.create_local "from" in 
-    let to_var = Ident.create_local "to_" in 
-    let mats = (from_var, from)::(to_var, to_)::mats in
-    let low, high =
-      match dir with
-      | Upto -> Lvar(from_var), Lvar(to_var)
-      | Downto -> Lvar(to_var), Lvar(from_var) in
-    let len =
-      Lprim(Psubint,
-        [Lprim(Paddint, [high; int 1], loc);
-        low], loc)
-    in
-    Lfor(id,Lvar(from_var), Lvar(to_var), dir, body), (len_var,len), mats
+(* Generate binding to make an "uninitialized" array *)
+let make_array ~loc ~kind ~size ~array =
+  match kind with
+  | Pgenarray ->
+      let init = Lprim(Pmakearray(Pgenarray, Immutable), [] ,loc) in
+      binding Variable Pgenval array init
+  | Pintarray | Paddrarray ->
+      let init = make_array_prim ~loc size (int 0) in
+      binding Strict Pgenval array init
+  | Pfloatarray ->
+      let init = make_floatarray_prim ~loc size in
+      binding Strict Pgenval array init
 
-let transl_loops block base_body ~loc ~scopes  ~transl_exp  =
-  List.fold_left (fun (body, lens, mats) type_comp ->
-    let new_body, new_len, mats =
-      transl_loop  ~transl_exp ~type_comp ~body ~scopes ~loc ~mats
-    in
-    new_body, new_len::lens, mats)
-  (base_body, [], []) block
-
-(*The block created here takes the result of the innerblock and writes it into
-  the array of arrays (arr).*)
-let transl_block global_counter  (comp_block, arrs) {clauses; guard;}
-    ~loc ~scopes ~transl_exp =
-  let arr = Ident.create_local "arr" in
-  let counter = Ident.create_local "counter" in
-  let body, res_len, array_kind =
-    match comp_block with
-    | Unguarded (body, Pgenarray) ->
-      let res_len = Ident.create_local "res_len" in
-      Lsequence(
-      Lifthenelse(
-        Lprim(Pintcomp(Ceq), [Lvar(counter); int 0], loc),
-        Lassign(arr, make_array ~loc (Lvar(res_len)) body),
-        Lprim(Parraysets(Pgenarray),
-          [Lvar(arr); Lvar(counter); body] ,loc)),
-      Lassign(counter, Lprim(Paddint, [Lvar(counter); int 1], loc))),
-      Some res_len, Pgenarray
-    | Unguarded (body, arr_kind) ->
-      Lsequence(
-        Lprim(Parraysets(arr_kind),[Lvar(arr); Lvar(counter); body], loc),
-        Lassign(counter, Lprim(Paddint, [Lvar(counter); int 1], loc))),
-      None, arr_kind
-    | Guarded (bdy_and_len, arr_kind, id) ->
-      let body = Ident.create_local "body" in
-      let len = Ident.create_local "len" in
-      Lstaticcatch(bdy_and_len, (id, [(body, Pgenval); (len, Pintval)]),
-        Lsequence(
-            Lsequence(
-              Lprim(Parraysets(arr_kind),
-                [Lvar(arr); Lvar(counter); Lvar(body)], loc),
-              Lprim(Parraysets(arr_kind),
-                [Lvar(arr); Lprim(Paddint, [Lvar(counter); (int 1)], loc);
-                Lvar(len)], loc)),
-          Lassign(counter, Lprim(Paddint, [Lvar(counter); (int 2)], loc)))),
-      None, arr_kind
+(* Generate code to initialise an element of an "uninitialised" array *)
+let init_array_elem ~loc ~kind ~size ~array ~index ~value =
+  let set_elem =
+    Lprim(Parraysetu kind, [Lvar array; Lvar index; Lvar value], loc)
   in
-  let body, arrs =
-    match guard with
-      | None ->
-        body, Array_of_arrays(arrs)
-      | Some guard ->
-        Lifthenelse(
-          (transl_exp ~scopes guard),
-          body,
-          lambda_unit
-        ), Array_of_filtered_arrays(arrs)
-  in
-  let body, lengths, materialize =
-    transl_loops  ~transl_exp  ~loc ~scopes clauses body in
-  let block_len = Ident.create_local "block_len" in
-  let body, len =
-    match global_counter, comp_block with
-    | Some gc, Unguarded _ ->
-      Lsequence(
-        body,
-        Lassign(gc, Lprim(Paddint, [Lvar(counter); Lvar(gc)], loc))),
-      Lvar(block_len)
-    | Some gc, Guarded _ ->
-      Lsequence(
-        body,
-        Lassign(gc, Lprim(Paddint,
-          [Lvar(gc);
-          Lprim(Pdivint(Unsafe), [Lvar(counter); int 2], loc)], loc))),
-      Lprim(Pmulint, [Lvar(block_len); int 2], loc)
-    | None, Unguarded _  -> body, Lvar(block_len)
-    | None, Guarded _  -> body, Lprim(Pmulint, [Lvar(block_len); int 2], loc)
-  in
-  let body =
-    match res_len with
-    | None ->
-      Llet(Strict, Pgenval, arr, make_array_of_kind ~loc array_kind len,
-        Lsequence(body, Lvar(arr)))
-    | Some res_len ->
-      Llet(Alias, Pintval, res_len, len,
-        Llet(Variable, Pgenval, arr, empty_arr ~loc,
-        Lsequence(body, Lvar(arr))))
-  in
-  let block_len_val = List.fold_left (fun (tot_len) (len_id, _len) ->
-      let new_tot_len =
-        match tot_len with
-        | None -> Lvar(len_id)
-        | Some tot_len -> Lprim(Pmulint, [Lvar(len_id); tot_len], loc)
+  match kind with
+  | Pgenarray ->
+      let is_first_iteration =
+        Lprim(Pintcomp Ceq, [Lvar index; int 0], loc)
       in
-      Some new_tot_len)
-    (None) lengths
-  in
-  let body =
-    Llet(Strict, Pintval, block_len,
-      Option.value block_len_val ~default:(int 0), body)
-  in
-  let body = List.fold_left (fun body (len_id, len) ->
-      Llet(Strict, Pintval, len_id, len, body))
-    (body) lengths
-  in
-  let body = List.fold_right (fun (id, arr) body ->
-    Llet(Strict, Pgenval, id, arr, body))
-    materialize body
-  in
-  match guard with
-  | None ->
-    Unguarded(Llet(Variable, Pintval, counter, int 0, body), Paddrarray),
-    arrs
-  | Some _ ->
-    let static_return_id = next_raise_count () in
-    Guarded(
-      Llet(Variable, Pintval, counter, int 0,
-        Lstaticraise(static_return_id, [body; Lvar(counter)])),
-      Paddrarray, static_return_id),
-    arrs
-
-let transl_concat_arrays arr arr_len arrs res_kind total_len ~loc  =
-  let res = Ident.create_local "res" in
-  let counter = Ident.create_local "counter" in
-  let rec transl_for arr arr_len arrs=
-    let i = Ident.create_local "i" in
-    match arrs with
-    | Array_of_elements ->
-      let blit =
-      Lsequence(
-        blit_array arr ~loc (int 0) (Lvar(res)) (Lvar(counter)) (arr_len),
-        Lassign(counter, Lprim(Paddint, [Lvar(counter); arr_len], loc)))
+      let make_array =
+        Lassign(array, make_array_prim ~loc size (Lvar value))
       in
-      (*Only create the array in the first iteration if its Pgenarray.*)
-      (match res_kind with
-      | Pgenarray ->
-        Lsequence(
-        Lifthenelse(
-          Lprim(Psequand, [
-            Lprim(Pintcomp(Ceq), [Lvar(counter); int 0], loc);
-            (*This check protects from trying to acces an empty array.*)
-            Lprim(Pintcomp(Cne), [arr_len; int 0], loc)], loc),
-          Lassign(res, make_array ~loc (Lvar(total_len))
-            (Lprim(Parrayrefs(res_kind), [arr; int 0], loc))),
+      Lifthenelse(is_first_iteration, make_array, set_elem)
+  | Pintarray | Paddrarray | Pfloatarray -> set_elem
+
+(* Generate code to blit elements into an "uninitialised" array *)
+let init_array_elems ~loc ~kind ~size ~array ~index ~src ~len =
+  let blit =
+    blit_array_prim ~loc (Lvar src) (int 0) (Lvar array) (Lvar index) (Lvar len)
+  in
+  match kind with
+  | Pgenarray ->
+      let is_first_iteration =
+        Lprim(Pintcomp Ceq, [Lvar index; int 0], loc)
+      in
+      let is_not_empty =
+        Lprim(Pintcomp(Cne), [Lvar len; int 0], loc)
+      in
+      let first_elem =
+        Lprim(Parrayrefu kind, [Lvar src; int 0], loc)
+      in
+      let make_array =
+        Lassign(array, make_array_prim ~loc size first_elem)
+      in
+      Lsequence(
+        Lifthenelse(is_first_iteration,
+          Lifthenelse(is_not_empty,
+                      Lsequence(make_array, blit),
+                      lambda_unit),
           lambda_unit),
         blit)
-      | Pintarray | Pfloatarray | Paddrarray -> blit)
-    | Array_of_arrays(arrs) ->
-      let sub_arr = Ident.create_local "sub_arr" in
+  | Pintarray | Paddrarray | Pfloatarray -> blit
+
+(* Binding for a counter *)
+let make_counter counter =
+  binding Variable Pintval counter (int 0)
+
+(* Code to increment a counter *)
+let increment_counter ~loc counter step =
+  Lassign(counter, Lprim(Paddint, [Lvar counter; step], loc))
+
+type block_lambda =
+  | Without_size of { body : lambda }
+  | With_size of { body : lambda; raise_count: int }
+
+let transl_arr_block ~transl_exp ~loc ~scopes
+          global_counter body array_kind value_kind block =
+  let length_var = Ident.create_local "len" in
+  let size =
+    match body with
+    | Without_size _ -> Lvar length_var
+    | With_size _ -> Lprim(Pmulint, [Lvar length_var; int 2], loc)
+  in
+  let result_array_var = Ident.create_local "arr" in
+  let result_array_binding =
+    make_array ~loc ~kind:array_kind ~size ~array:result_array_var
+  in
+  let counter_var = Ident.create_local "counter" in
+  let counter_binding = make_counter counter_var in
+  let elem_var = Ident.create_local "elem" in
+  let init_elem =
+    init_array_elem ~loc ~kind:array_kind ~size
+      ~array:result_array_var ~index:counter_var ~value:elem_var
+  in
+  let set_result =
+    match body with
+    | Without_size {body} ->
+        Llet(Strict, value_kind, elem_var, body,
+          Lsequence(init_elem, increment_counter ~loc counter_var (int 1)))
+    | With_size {body; raise_count} ->
+        let elem_len_var = Ident.create_local "len" in
+        let set_len =
+          Lprim(Parraysetu Paddrarray,
+            [Lvar result_array_var;
+             Lprim(Paddint, [Lvar counter_var; int 1], loc);
+             Lvar elem_len_var], loc)
+        in
+        Lstaticcatch(body,
+          (raise_count, [(elem_var, Pgenval); (elem_len_var, Pintval)]),
+          Lsequence(init_elem, Lsequence(set_len,
+             increment_counter ~loc counter_var (int 2))))
+  in
+  let bindings, loops =
+    iterate_arr_block ~transl_exp ~loc ~scopes block length_var set_result
+  in
+  let bindings =
+    bindings @ [result_array_binding; counter_binding]
+  in
+  let body =
+    match global_counter with
+    | None -> loops
+    | Some global_counter_var ->
       let len =
-        Lprim((Parraylength(Paddrarray)), [Lvar(sub_arr)], loc)
+        match body with
+        | Without_size _ -> Lvar counter_var
+        | With_size _ -> Lprim(Pdivint Unsafe, [Lvar counter_var; int 2], loc)
       in
-      Lfor(i, int 0, Lprim(Psubint, [arr_len; int 1], loc), Upto,
-        Llet(Strict, Pgenval, sub_arr,
-          Lprim(Parrayrefs(Paddrarray), [arr; Lvar(i)], loc),
-          transl_for (Lvar(sub_arr)) len arrs))
-    | Array_of_filtered_arrays(arrs) ->
-      let sub_arr = Ident.create_local "sub_arr" in
-      let sub_arr_len = Ident.create_local "sub_arr_len" in
-      Llet(Variable, Pintval, i, int 0,
-      Lwhile(Lprim(Pintcomp(Clt), [Lvar(i); arr_len], loc),
-        Lsequence(
-            Llet(Strict, Pgenval,  sub_arr,
-              Lprim(Parrayrefs(Paddrarray), [arr; Lvar(i)], loc),
-              Llet(Strict, Pintval, sub_arr_len,
-                Lprim(Parrayrefs(Paddrarray),
-                  [arr; Lprim(Paddint, [Lvar(i); int 1], loc)],loc),
-                transl_for (Lvar(sub_arr)) (Lvar(sub_arr_len)) arrs)),
-          Lassign(i, Lprim(Paddint, [Lvar(i); int 2], loc))
-        )))
+      Lsequence(loops, increment_counter ~loc global_counter_var len)
   in
-  (*Remove the outer most layer. The outermost array would always be of size
-    one, thats why its always unwrapped (arr, arr_len).*)
-  let arrs =
-    match arrs with
-    | Array_of_elements -> arrs
-    | Array_of_arrays(arrs) -> arrs
-    | Array_of_filtered_arrays(arrs) -> arrs
-  in
-  match res_kind with
-  | Pgenarray ->
-    Llet(Variable, Pgenval, res, empty_arr ~loc,
-      Llet(Variable, Pintval, counter, (int 0),
-        Lsequence(transl_for arr arr_len arrs, Lvar(res))))
-  | Pintarray | Pfloatarray | Paddrarray as kind ->
-    Llet(Strict, Pgenval, res, make_array_of_kind ~loc kind (Lvar(total_len)),
-      Llet(Variable, Pintval, counter, (int 0),
-        Lsequence(transl_for arr arr_len arrs, Lvar(res))))
+  match block.guard with
+  | None ->
+      let body =
+        gen_bindings bindings (Lsequence(body, Lvar result_array_var))
+      in
+      Without_size { body }
+  | Some _ ->
+      let raise_count = next_raise_count () in
+      let return =
+        Lstaticraise(raise_count, [Lvar result_array_var; Lvar counter_var])
+      in
+      let body =
+        gen_bindings bindings (Lsequence(body, return))
+      in
+      With_size { body; raise_count }
 
-let transl_arr_comprehension body blocks ~array_kind ~scopes ~loc ~transl_exp =
-  (*The global counter is required when the size of the result array is not
-    known in advance.*)
-  let global_counter =
-    match blocks with
-    | [{ guard = None; _}] -> None
-    | _ -> Some (Ident.create_local "global_counter")
+let sub_array ~loc src src_pos len =
+  let prim =
+    Primitive.simple ~name:"caml_array_sub" ~arity:3 ~alloc:true
   in
-  let base_block =
-    transl_block ~transl_exp ~loc ~scopes global_counter
-      (Unguarded(transl_exp ~scopes body, array_kind),
-        Array_of_elements)
-      (List.hd blocks)
-  in
-  let translated_blocks, arrs =
-    List.fold_left
-      (fun acc el ->
-        transl_block  ~transl_exp  ~loc ~scopes None acc el )
-      base_block (List.tl blocks)
-  in
-  match translated_blocks, global_counter with
-  | Unguarded(body, _kind), Some gc ->
-    let arr = Ident.create_local "arr" in
-    let len = Ident.create_local "len_var" in
-    Llet(
-      Variable, Pintval, gc, int 0,
-      Llet(Strict, Pgenval, arr, body,
-        Llet(Alias, Pintval, len,
-          Lprim((Parraylength(Paddrarray)), [Lvar(arr)], loc),
-          transl_concat_arrays ~loc
-            (Lvar(arr)) (Lvar(len)) arrs array_kind gc)))
-  | Unguarded(body, _kind), None -> body
-  | Guarded(arr_and_len, _, id), Some gc ->
-    let len = Ident.create_local "len" in
-    let arr = Ident.create_local "arr" in
-    Llet(
-      Variable, Pintval, gc, int 0,
-      Lstaticcatch(arr_and_len, (id, [(arr, Pgenval); (len, Pintval)]),
-          transl_concat_arrays ~loc
-            (Lvar(arr)) (Lvar(len)) arrs array_kind gc))
-  | Guarded _, None -> assert false
+  Lprim (Pccall prim, [src; src_pos; len], loc)
 
+let transl_single_arr_block ~transl_exp ~loc ~scopes
+      block body array_kind value_kind =
+  let body =
+    transl_arr_block ~transl_exp ~loc ~scopes None
+      (Without_size {body}) array_kind value_kind block
+  in
+  match body with
+  | Without_size { body } -> body
+  | With_size { body; raise_count } ->
+      let array_var = Ident.create_local "array" in
+      let len_var = Ident.create_local "len" in
+      Lstaticcatch(body,
+          (raise_count, [(array_var, Pgenval); (len_var, Pintval)]),
+          sub_array ~loc (Lvar array_var) (int 0) (Lvar len_var))
+
+type intermediate_array_shape =
+  | Array_of_elements
+  | Array_of_arrays of intermediate_array_shape
+  | Array_of_filtered_arrays of intermediate_array_shape
+
+let concat_arrays ~loc arr kind shape global_count_var =
+  let res_var = Ident.create_local "res" in
+  let res_binding =
+    make_array ~loc ~kind ~size:(Lvar global_count_var) ~array:res_var
+  in
+  let counter_var = Ident.create_local "counter" in
+  let counter_binding = make_counter counter_var in
+  let rec loop shape arr_var len_var =
+    let kind =
+      match shape with
+      | Array_of_elements -> kind
+      | Array_of_arrays _ | Array_of_filtered_arrays _ -> Paddrarray
+    in
+    let len_var, bindings =
+      match len_var with
+      | Some var -> var, []
+      | None ->
+        let var = Ident.create_local "len" in
+        let init = Lprim((Parraylength kind), [Lvar(arr_var)], loc) in
+        let binding = binding Alias Pintval var init in
+        var, [binding]
+    in
+    match shape with
+    | Array_of_elements ->
+        gen_bindings bindings
+          (Lsequence(
+             init_array_elems ~loc ~kind ~size:(Lvar global_count_var)
+               ~array:res_var ~index:counter_var ~src:arr_var ~len:len_var,
+             increment_counter ~loc counter_var (Lvar len_var)))
+    | Array_of_arrays shape ->
+        let index_var = Ident.create_local "index" in
+        let sub_arr_var = Ident.create_local "arr" in
+        let last_index = Lprim(Psubint, [Lvar len_var; int 1], loc) in
+        let sub_arr =
+          Lprim(Parrayrefu kind, [Lvar arr_var; Lvar index_var], loc)
+        in
+        gen_bindings bindings
+          (Lfor(index_var, int 0, last_index, Upto,
+             Llet(Strict, Pgenval, sub_arr_var, sub_arr,
+               loop shape sub_arr_var None)))
+    | Array_of_filtered_arrays shape ->
+        let index_var = Ident.create_local "index" in
+        let index_binding = make_counter index_var in
+        let sub_arr_var = Ident.create_local "arr" in
+        let sub_arr =
+          Lprim(Parrayrefu kind, [Lvar arr_var; Lvar index_var], loc)
+        in
+        let sub_arr_len_var = Ident.create_local "len" in
+        let sub_arr_len =
+          Lprim(Parrayrefu kind,
+                [Lvar arr_var; Lprim(Paddint, [Lvar index_var; int 1], loc)], loc)
+        in
+        gen_bindings bindings
+          (gen_binding index_binding
+            (Lwhile(Lprim(Pintcomp Clt, [Lvar index_var; Lvar len_var], loc),
+               Lsequence(
+                 Llet(Strict, Pgenval, sub_arr_var, sub_arr,
+                   Llet(Strict, Pintval, sub_arr_len_var, sub_arr_len,
+                     loop shape sub_arr_var (Some sub_arr_len_var))),
+                 increment_counter ~loc index_var (int 2)))))
+  in
+  match arr with
+  | Without_size { body } ->
+      let array_var = Ident.create_local "array" in
+      Llet(Strict, Pgenval, array_var, body,
+           gen_binding res_binding
+             (gen_binding counter_binding
+                (Lsequence
+                   (loop shape array_var None,
+                    Lvar res_var))))
+  | With_size { body; raise_count } ->
+      let array_var = Ident.create_local "array" in
+      let len_var = Ident.create_local "len" in
+      Lstaticcatch(body,
+          (raise_count, [(array_var, Pgenval); (len_var, Pintval)]),
+           gen_binding res_binding
+             (gen_binding counter_binding
+                ((Lsequence
+                    (loop shape array_var (Some len_var),
+                     Lvar res_var)))))
+
+let transl_arr_comprehension ~transl_exp ~loc ~scopes
+      ~array_kind exp blocks =
+  let body = transl_exp ~scopes exp in
+  let value_kind = Typeopt.value_kind exp.exp_env exp.exp_type in
+  match blocks with
+  | [] -> assert false
+  | [block] ->
+      transl_single_arr_block ~transl_exp ~loc ~scopes
+        block body array_kind value_kind
+  | inner_block :: rest ->
+      let counter_var = Ident.create_local "counter" in
+      let counter_binding = make_counter counter_var in
+      let body =
+        transl_arr_block ~transl_exp ~loc ~scopes (Some counter_var)
+          (Without_size {body}) array_kind value_kind inner_block
+      in
+      let shape, body =
+        List.fold_left
+          (fun (shape, body) block ->
+             let shape =
+               match body with
+               | Without_size _ -> Array_of_arrays shape
+               | With_size _ -> Array_of_filtered_arrays shape
+             in
+             let body =
+               transl_arr_block ~transl_exp ~loc ~scopes None
+                 body Paddrarray Pgenval block
+             in
+             shape, body)
+          (Array_of_elements, body) rest
+      in
+      gen_binding counter_binding
+        (concat_arrays ~loc body array_kind shape counter_var)
 
 let from_to_comp_prim ~dir=
   let function_name = match dir with
@@ -378,7 +480,7 @@ let transl_list_comprehension body blocks ~scopes ~loc ~transl_exp  =
         in
         let body = List.fold_right (fun (id, arr) body ->
           Llet(Strict, Pgenval, id, arr, body))
-          materialize (body) 
+          materialize body
         in
         body, acc_var)
     (bdy, acc_var) blocks

--- a/lambda/translcomprehension.mli
+++ b/lambda/translcomprehension.mli
@@ -3,9 +3,12 @@ open Lambda
 open Typedtree
 open Debuginfo.Scoped_location
 
-val transl_arr_comprehension: expression -> comprehension list
-    -> array_kind:array_kind -> scopes:scopes -> loc:scoped_location
-    -> transl_exp:(scopes:scopes -> expression -> lambda) -> lambda
+val transl_arr_comprehension:
+  transl_exp:(scopes:scopes -> expression -> lambda)
+  -> loc:scoped_location -> scopes:scopes
+  -> array_kind:array_kind
+  -> expression -> comprehension list
+  -> lambda
 
 val transl_list_comprehension: expression -> comprehension list
     -> scopes:scopes -> loc:scoped_location

--- a/testsuite/tests/comprehensions/comprehensions.ml
+++ b/testsuite/tests/comprehensions/comprehensions.ml
@@ -532,7 +532,7 @@ List.rev !var;;
 [%%expect{|
 - : unit = ()
 - : int array = [|0; 1; 2; 3; 4; 5; 0; 1; 2; 3; 4; 5|]
-- : int list = [3; 4; 0; 5]
+- : int list = [0; 5; 3; 4]
 |}];;
 
 var := [];;

--- a/testsuite/tests/comprehensions/comprehensions.ml
+++ b/testsuite/tests/comprehensions/comprehensions.ml
@@ -532,7 +532,7 @@ List.rev !var;;
 [%%expect{|
 - : unit = ()
 - : int array = [|0; 1; 2; 3; 4; 5; 0; 1; 2; 3; 4; 5|]
-- : int list = [0; 5; 3; 4]
+- : int list = [3; 4; 0; 5]
 |}];;
 
 var := [];;


### PR DESCRIPTION
Attempt to make the translation of array comprehensions easier to follow.

This also changed the order of side-effects between `and` clauses. I think both orders are defensible -- and OCaml tends to say the ordering between things separated by `and` is implementation defined anyway -- but this order falls out of this code more naturally and is probably the slightly more expected order.